### PR TITLE
fix: support shallow clones by reading parent SHA from commit metadata

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -80,8 +80,9 @@ runs:
         if [ "$TRAILER_VALUE" = "$TRAILER_ID" ]; then
           echo "HEAD has matching trailer (X-Commit-Rewrite-ID: $TRAILER_ID)"
           echo "should_reset=true" >> $GITHUB_OUTPUT
-          # Store parent SHA for later use
-          PARENT_SHA=$(git rev-parse HEAD~1)
+          # Store parent SHA for later use (works even in shallow clones)
+          # The commit object contains parent SHA even if parent commit is not fetched
+          PARENT_SHA=$(git log -1 --format=%P HEAD | head -1)
           echo "parent_sha=$PARENT_SHA" >> $GITHUB_OUTPUT
         else
           echo "HEAD does not have matching trailer"


### PR DESCRIPTION
## Summary

This PR makes the action work with shallow clones (like the default behavior of `actions/checkout`) by changing how we retrieve the parent commit SHA.

## Changes

- Replace `git rev-parse HEAD~1` with `git log -1 --format=%P HEAD`
- This works because shallow clones still contain the full commit object metadata (including parent SHA references), they just don't have the actual parent commit objects

## Why this matters

The GitHub Actions `checkout` action uses shallow clones by default (`fetch-depth: 1`). With this change, users won't need to specify `fetch-depth: 2` or deeper to use our action.

## Test plan

- [ ] Test with a shallow clone (`fetch-depth: 1`)
- [ ] Test with a full clone
- [ ] Verify parent SHA is correctly retrieved in both cases

🤖 Generated with [Claude Code](https://claude.ai/code)